### PR TITLE
ci: dual-publish site image to GHCR for homelab migration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,8 @@ on:
 
 permissions:
   id-token: write
-  contents: read    # This is required for actions/checkout
+  contents: write   # required to push the auto-bumped git tag
+  packages: write   # required to push to ghcr.io
 
 jobs:
   build:
@@ -16,22 +17,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # full history so the tag action can compute the next semver
+          fetch-depth: 0
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::339843249992:role/github-website-upload
           role-session-name: github-liskl-com-liskl-frontend
           aws-region: "us-east-1"
-
-      - name: Where
-        run: echo "$(pwd)"
-
-      - name: What
-        run: find "$(pwd)"
 
       - name: Deploy to S3
         if: github.ref == 'refs/heads/master'
@@ -44,3 +40,35 @@ jobs:
           aws cloudfront create-invalidation --distribution-id=$CLOUDFRONT_DISTRIBUTION_ID --paths '/*'
         env:
           CLOUDFRONT_DISTRIBUTION_ID: E3VU1O4N3QRZPH
+
+      - name: Compute next semver and tag the commit
+        id: tag
+        if: github.ref == 'refs/heads/master'
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          tag_prefix: v
+
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/master'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: github.ref == 'refs/heads/master'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image to GHCR
+        if: github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/liskl/com_liskl_frontend:${{ steps.tag.outputs.new_tag }}
+            ghcr.io/liskl/com_liskl_frontend:latest


### PR DESCRIPTION
## Summary

First of two PRs (this one + a paired PR in `liskl/homelab`) that migrate `www.liskl.com` from AWS S3/CloudFront to the homelab k3s cluster. AWS keeps running unchanged during the cutover window.

- Adds GHCR build/push using auto-bumped semver tags via `mathieudutour/github-tag-action@v6.2` (first build on master → `v0.0.1`, then patch-bumps each subsequent push). Publishes `ghcr.io/liskl/com_liskl_frontend:vX.Y.Z` + `:latest`.
- Keeps the existing S3 sync + CloudFront invalidation steps untouched (parallel publish — Flux on the homelab will pull the new image, but external DNS still points to CloudFront until cutover).
- Bumps `actions/checkout@v1 → v4` and `aws-actions/configure-aws-credentials@v1 → v4` (both v1s are deprecated and break OIDC on newer runners).
- Drops the `Where` / `What` debug steps that just dump pwd and `find $(pwd)` to logs.

The semver tags feed the Flux `ImageRepository` + `ImagePolicy` + `ImageUpdateAutomation` chain added in the paired homelab PR — once a new tag is pushed here, Flux discovers it, rewrites the deployment overlay, and rolls out the pods.

## Test plan

- [ ] Merge to `master`; verify CI completes without errors.
- [ ] `mathieudutour/github-tag-action` step creates git tag `v0.0.1` and pushes it.
- [ ] `docker pull ghcr.io/liskl/com_liskl_frontend:v0.0.1` works **after** marking the package public in GitHub Settings → Packages.
- [ ] Existing `Deploy to S3` step still runs and `www.liskl.com` continues to serve from CloudFront.
- [ ] Confirm GHCR push permission works (`packages: write` was added to the workflow's permissions block).