### PR TITLE
feat: add 2025 OSS projects and 2026 activity to Recent News

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ site/                      # Deployable static content
 Granular breakdown:
 
 - `src/` - Template source files (edit these)
-- `site/` - Generated output (served by nginx, deployed to S3 and to the homelab k3s pod)
+- `site/` - Generated output (served by nginx, deployed to S3 and to the homelab k8s pod)
 - `site/assets/css/` - Stylesheets (Bootstrap 4, custom CSS)
 - `site/assets/js/` - JavaScript (jQuery, Bootstrap, custom)
 - `site/assets/img/` - Images

--- a/site/index.html
+++ b/site/index.html
@@ -121,7 +121,7 @@
               </li>
               <li class='sub'>Technologies &amp; Tools:
                 <ul class='sub'>
-                  <li class='sub'><strong>k3s + Flux GitOps</strong> - Self-hosted homelab cluster with Flux Kustomization reconciliation and image-automation for hands-off rollouts</li>
+                  <li class='sub'><strong>k8s + Flux GitOps</strong> - Self-hosted homelab cluster with Flux Kustomization reconciliation and image-automation for hands-off rollouts</li>
                   <li class='sub'><strong>kgateway / Gateway API</strong> - Envoy-based Gateway with SNI-per-hostname HTTPS listeners</li>
                   <li class='sub'><strong>cert-manager</strong> - Let's Encrypt production and staging ClusterIssuers, plus a private homelab CA for internal mTLS</li>
                   <li class='sub'><strong>OpenTelemetry + Grafana + Loki / Tempo</strong> - Observability stack for plex-db-analyzer microservices</li>
@@ -134,7 +134,7 @@
           <li>
             <strong>May 2026</strong>
             <ul class='sub'>
-              <li class='sub'>Migrated <a href='/'>liskl.com</a> off AWS S3 + CloudFront onto a self-hosted k3s homelab cluster - kgateway SNI listeners with Let's Encrypt production certs, Flux image-automation driven by semver auto-bump CI, dual-publish during cutover</li>
+              <li class='sub'>Migrated <a href='/'>liskl.com</a> off AWS S3 + CloudFront onto a self-hosted k8s homelab cluster - kgateway SNI listeners with Let's Encrypt production certs, Flux image-automation driven by semver auto-bump CI, dual-publish during cutover</li>
               <li class='sub'>plex-db-analyzer microservices - shipped OpenTelemetry metrics (5s export interval) and a Grafana ingest-pipeline dashboard</li>
             </ul>
           </li>
@@ -174,7 +174,7 @@
             <strong>Dec 2025</strong>
             <ul class='sub'>
               <li class='sub'>Shipped <strong><a href='https://github.com/liskl/backstage-adr-plugin'>backstage-adr-plugin</a></strong> v1 - Architecture Decision Record plugin for Backstage IDP across three release phases (Core Foundation, CRUD + PR Workflow, Advanced filtering with saved filter presets)</li>
-              <li class='sub'>Kicked off the <strong><a href='https://github.com/liskl/homelab'>liskl/homelab</a></strong> repo - bootstrapped k3s with cert-manager + private CA HTTPS, deployed FlashPaper encrypted pastebin, home.liskl.com landing page, and the Furious Fruits HTML5 game</li>
+              <li class='sub'>Kicked off the <strong><a href='https://github.com/liskl/homelab'>liskl/homelab</a></strong> repo - bootstrapped k8s with cert-manager + private CA HTTPS, deployed FlashPaper encrypted pastebin, home.liskl.com landing page, and the Furious Fruits HTML5 game</li>
             </ul>
           </li>
           <li>
@@ -325,7 +325,7 @@
                   <li class='sub'><strong>Terraform</strong> - Infrastructure as Code for client infrastructure deployments</li>
                   <li class='sub'><strong>Infracost</strong> - Cloud cost estimation and optimization tooling</li>
                   <li class='sub'><strong>AWS Services</strong> - CloudFront, ALB configuration, EKS infrastructure</li>
-                  <li class='sub'><strong>K3s</strong> - Lightweight Kubernetes contributions and documentation</li>
+                  <li class='sub'><strong>K8s</strong> - Lightweight Kubernetes contributions and documentation</li>
                 </ul>
               </li>
               <li class='sub'>Key Focus Areas:

--- a/site/index.html
+++ b/site/index.html
@@ -325,7 +325,7 @@
                   <li class='sub'><strong>Terraform</strong> - Infrastructure as Code for client infrastructure deployments</li>
                   <li class='sub'><strong>Infracost</strong> - Cloud cost estimation and optimization tooling</li>
                   <li class='sub'><strong>AWS Services</strong> - CloudFront, ALB configuration, EKS infrastructure</li>
-                  <li class='sub'><strong>K8s</strong> - Lightweight Kubernetes contributions and documentation</li>
+                  <li class='sub'><strong>K3s</strong> - Lightweight Kubernetes contributions and documentation</li>
                 </ul>
               </li>
               <li class='sub'>Key Focus Areas:

--- a/site/index.html
+++ b/site/index.html
@@ -107,6 +107,45 @@
         <h2>Recent News</h2>
         <ul>
           <li>
+            <strong>2026</strong>
+            <ul class='sub'>
+              <li class='sub'>Open Source / Personal Projects:
+                <ul class='sub'>
+                  <li class='sub'><strong><a href='https://github.com/liskl/code-review-graph'>code-review-graph</a></strong> - Local knowledge graph for Claude Code that builds a persistent map of the codebase, reading only what matters - ~6.8x fewer tokens on reviews and up to 49x on daily coding tasks</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/cc-skill-visual-explainer'>cc-skill-visual-explainer</a></strong> - Claude Code agent skill that generates rich HTML pages or slide decks for diagrams, diff reviews, plan audits, data tables, and project recaps</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/coolledux-controller'>coolledux-controller</a></strong> - Go service for CoolLEDUX 16x96 RGB LED matrix signs over BLE with REST API, MQTT + Home Assistant auto-discovery, and animated text / image / countdown / scoreboard overlays</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/FlashPaper'>FlashPaper</a></strong> - Self-hosted, self-destructing encrypted pastebin in Go, deployed to the homelab cluster</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/ai-consensus-poc'>ai-consensus-poc</a></strong> - Multi-agent consensus prototype in Go</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/kind-aws-irsa-example'>kind-aws-irsa-example</a></strong> - Reference for using IAM Roles for Service Accounts (IRSA) in self-hosted Kubernetes clusters</li>
+                </ul>
+              </li>
+              <li class='sub'>Technologies &amp; Tools:
+                <ul class='sub'>
+                  <li class='sub'><strong>k3s + Flux GitOps</strong> - Self-hosted homelab cluster with Flux Kustomization reconciliation and image-automation for hands-off rollouts</li>
+                  <li class='sub'><strong>kgateway / Gateway API</strong> - Envoy-based Gateway with SNI-per-hostname HTTPS listeners</li>
+                  <li class='sub'><strong>cert-manager</strong> - Let's Encrypt production and staging ClusterIssuers, plus a private homelab CA for internal mTLS</li>
+                  <li class='sub'><strong>OpenTelemetry + Grafana + Loki / Tempo</strong> - Observability stack for plex-db-analyzer microservices</li>
+                  <li class='sub'><strong>Go</strong> - Hardware control (BLE), scraping, and metrics export services</li>
+                  <li class='sub'><strong>Claude Code agent skills</strong> - Code-review knowledge graphs, visual explainers, and repo-specific custom skills</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <strong>May 2026</strong>
+            <ul class='sub'>
+              <li class='sub'>Migrated <a href='/'>liskl.com</a> off AWS S3 + CloudFront onto a self-hosted k3s homelab cluster - kgateway SNI listeners with Let's Encrypt production certs, Flux image-automation driven by semver auto-bump CI, dual-publish during cutover</li>
+              <li class='sub'>plex-db-analyzer microservices - shipped OpenTelemetry metrics (5s export interval) and a Grafana ingest-pipeline dashboard</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Mar 2026</strong>
+            <ul class='sub'>
+              <li class='sub'>Published <strong><a href='https://github.com/liskl/code-review-graph'>code-review-graph</a></strong> - persistent codebase knowledge graph that lets Claude Code read only what matters, cutting tokens on code review tasks by ~6.8x</li>
+              <li class='sub'>Published <strong><a href='https://github.com/liskl/cc-skill-visual-explainer'>cc-skill-visual-explainer</a></strong> - agent skill for rendering diagrams, diffs, plan audits, and data tables as HTML pages or slide decks</li>
+            </ul>
+          </li>
+          <li>
             <strong>2025</strong>
             <ul class='sub'>
               <li class='sub'>Technologies &amp; Tools:
@@ -121,6 +160,21 @@
                   <li class='sub'><strong>Kubernetes RBAC</strong> - Implemented comprehensive role-based access control across platform and application clusters</li>
                 </ul>
               </li>
+              <li class='sub'>Open Source / Personal Projects:
+                <ul class='sub'>
+                  <li class='sub'><strong><a href='https://github.com/liskl/backstage-adr-plugin'>backstage-adr-plugin</a></strong> - Architecture Decision Record plugin for Backstage IDP, shipped in three phases: core foundation, CRUD + PR-backed workflow, and advanced filtering with saved filter presets</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/llm-council'>llm-council</a></strong> - Multi-LLM consensus experiment</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/esphome-levoit-air-purifier'>esphome-levoit-air-purifier</a></strong> - ESPHome custom component for Levoit smart WiFi air purifiers</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/k8s-rds'>k8s-rds</a></strong> - Continued maintenance of the Kubernetes RDS provisioner</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <strong>Dec 2025</strong>
+            <ul class='sub'>
+              <li class='sub'>Shipped <strong><a href='https://github.com/liskl/backstage-adr-plugin'>backstage-adr-plugin</a></strong> v1 - Architecture Decision Record plugin for Backstage IDP across three release phases (Core Foundation, CRUD + PR Workflow, Advanced filtering with saved filter presets)</li>
+              <li class='sub'>Kicked off the <strong><a href='https://github.com/liskl/homelab'>liskl/homelab</a></strong> repo - bootstrapped k3s with cert-manager + private CA HTTPS, deployed FlashPaper encrypted pastebin, home.liskl.com landing page, and the Furious Fruits HTML5 game</li>
             </ul>
           </li>
           <li>

--- a/src/index.tmpl
+++ b/src/index.tmpl
@@ -89,6 +89,45 @@
         <h2>Recent News</h2>
         <ul>
           <li>
+            <strong>2026</strong>
+            <ul class='sub'>
+              <li class='sub'>Open Source / Personal Projects:
+                <ul class='sub'>
+                  <li class='sub'><strong><a href='https://github.com/liskl/code-review-graph'>code-review-graph</a></strong> - Local knowledge graph for Claude Code that builds a persistent map of the codebase, reading only what matters - ~6.8x fewer tokens on reviews and up to 49x on daily coding tasks</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/cc-skill-visual-explainer'>cc-skill-visual-explainer</a></strong> - Claude Code agent skill that generates rich HTML pages or slide decks for diagrams, diff reviews, plan audits, data tables, and project recaps</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/coolledux-controller'>coolledux-controller</a></strong> - Go service for CoolLEDUX 16x96 RGB LED matrix signs over BLE with REST API, MQTT + Home Assistant auto-discovery, and animated text / image / countdown / scoreboard overlays</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/FlashPaper'>FlashPaper</a></strong> - Self-hosted, self-destructing encrypted pastebin in Go, deployed to the homelab cluster</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/ai-consensus-poc'>ai-consensus-poc</a></strong> - Multi-agent consensus prototype in Go</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/kind-aws-irsa-example'>kind-aws-irsa-example</a></strong> - Reference for using IAM Roles for Service Accounts (IRSA) in self-hosted Kubernetes clusters</li>
+                </ul>
+              </li>
+              <li class='sub'>Technologies &amp; Tools:
+                <ul class='sub'>
+                  <li class='sub'><strong>k3s + Flux GitOps</strong> - Self-hosted homelab cluster with Flux Kustomization reconciliation and image-automation for hands-off rollouts</li>
+                  <li class='sub'><strong>kgateway / Gateway API</strong> - Envoy-based Gateway with SNI-per-hostname HTTPS listeners</li>
+                  <li class='sub'><strong>cert-manager</strong> - Let's Encrypt production and staging ClusterIssuers, plus a private homelab CA for internal mTLS</li>
+                  <li class='sub'><strong>OpenTelemetry + Grafana + Loki / Tempo</strong> - Observability stack for plex-db-analyzer microservices</li>
+                  <li class='sub'><strong>Go</strong> - Hardware control (BLE), scraping, and metrics export services</li>
+                  <li class='sub'><strong>Claude Code agent skills</strong> - Code-review knowledge graphs, visual explainers, and repo-specific custom skills</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <strong>May 2026</strong>
+            <ul class='sub'>
+              <li class='sub'>Migrated <a href='/'>liskl.com</a> off AWS S3 + CloudFront onto a self-hosted k3s homelab cluster - kgateway SNI listeners with Let's Encrypt production certs, Flux image-automation driven by semver auto-bump CI, dual-publish during cutover</li>
+              <li class='sub'>plex-db-analyzer microservices - shipped OpenTelemetry metrics (5s export interval) and a Grafana ingest-pipeline dashboard</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Mar 2026</strong>
+            <ul class='sub'>
+              <li class='sub'>Published <strong><a href='https://github.com/liskl/code-review-graph'>code-review-graph</a></strong> - persistent codebase knowledge graph that lets Claude Code read only what matters, cutting tokens on code review tasks by ~6.8x</li>
+              <li class='sub'>Published <strong><a href='https://github.com/liskl/cc-skill-visual-explainer'>cc-skill-visual-explainer</a></strong> - agent skill for rendering diagrams, diffs, plan audits, and data tables as HTML pages or slide decks</li>
+            </ul>
+          </li>
+          <li>
             <strong>2025</strong>
             <ul class='sub'>
               <li class='sub'>Technologies &amp; Tools:
@@ -103,6 +142,21 @@
                   <li class='sub'><strong>Kubernetes RBAC</strong> - Implemented comprehensive role-based access control across platform and application clusters</li>
                 </ul>
               </li>
+              <li class='sub'>Open Source / Personal Projects:
+                <ul class='sub'>
+                  <li class='sub'><strong><a href='https://github.com/liskl/backstage-adr-plugin'>backstage-adr-plugin</a></strong> - Architecture Decision Record plugin for Backstage IDP, shipped in three phases: core foundation, CRUD + PR-backed workflow, and advanced filtering with saved filter presets</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/llm-council'>llm-council</a></strong> - Multi-LLM consensus experiment</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/esphome-levoit-air-purifier'>esphome-levoit-air-purifier</a></strong> - ESPHome custom component for Levoit smart WiFi air purifiers</li>
+                  <li class='sub'><strong><a href='https://github.com/liskl/k8s-rds'>k8s-rds</a></strong> - Continued maintenance of the Kubernetes RDS provisioner</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <strong>Dec 2025</strong>
+            <ul class='sub'>
+              <li class='sub'>Shipped <strong><a href='https://github.com/liskl/backstage-adr-plugin'>backstage-adr-plugin</a></strong> v1 - Architecture Decision Record plugin for Backstage IDP across three release phases (Core Foundation, CRUD + PR Workflow, Advanced filtering with saved filter presets)</li>
+              <li class='sub'>Kicked off the <strong><a href='https://github.com/liskl/homelab'>liskl/homelab</a></strong> repo - bootstrapped k3s with cert-manager + private CA HTTPS, deployed FlashPaper encrypted pastebin, home.liskl.com landing page, and the Furious Fruits HTML5 game</li>
             </ul>
           </li>
           <li>

--- a/src/index.tmpl
+++ b/src/index.tmpl
@@ -103,7 +103,7 @@
               </li>
               <li class='sub'>Technologies &amp; Tools:
                 <ul class='sub'>
-                  <li class='sub'><strong>k3s + Flux GitOps</strong> - Self-hosted homelab cluster with Flux Kustomization reconciliation and image-automation for hands-off rollouts</li>
+                  <li class='sub'><strong>k8s + Flux GitOps</strong> - Self-hosted homelab cluster with Flux Kustomization reconciliation and image-automation for hands-off rollouts</li>
                   <li class='sub'><strong>kgateway / Gateway API</strong> - Envoy-based Gateway with SNI-per-hostname HTTPS listeners</li>
                   <li class='sub'><strong>cert-manager</strong> - Let's Encrypt production and staging ClusterIssuers, plus a private homelab CA for internal mTLS</li>
                   <li class='sub'><strong>OpenTelemetry + Grafana + Loki / Tempo</strong> - Observability stack for plex-db-analyzer microservices</li>
@@ -116,7 +116,7 @@
           <li>
             <strong>May 2026</strong>
             <ul class='sub'>
-              <li class='sub'>Migrated <a href='/'>liskl.com</a> off AWS S3 + CloudFront onto a self-hosted k3s homelab cluster - kgateway SNI listeners with Let's Encrypt production certs, Flux image-automation driven by semver auto-bump CI, dual-publish during cutover</li>
+              <li class='sub'>Migrated <a href='/'>liskl.com</a> off AWS S3 + CloudFront onto a self-hosted k8s homelab cluster - kgateway SNI listeners with Let's Encrypt production certs, Flux image-automation driven by semver auto-bump CI, dual-publish during cutover</li>
               <li class='sub'>plex-db-analyzer microservices - shipped OpenTelemetry metrics (5s export interval) and a Grafana ingest-pipeline dashboard</li>
             </ul>
           </li>
@@ -156,7 +156,7 @@
             <strong>Dec 2025</strong>
             <ul class='sub'>
               <li class='sub'>Shipped <strong><a href='https://github.com/liskl/backstage-adr-plugin'>backstage-adr-plugin</a></strong> v1 - Architecture Decision Record plugin for Backstage IDP across three release phases (Core Foundation, CRUD + PR Workflow, Advanced filtering with saved filter presets)</li>
-              <li class='sub'>Kicked off the <strong><a href='https://github.com/liskl/homelab'>liskl/homelab</a></strong> repo - bootstrapped k3s with cert-manager + private CA HTTPS, deployed FlashPaper encrypted pastebin, home.liskl.com landing page, and the Furious Fruits HTML5 game</li>
+              <li class='sub'>Kicked off the <strong><a href='https://github.com/liskl/homelab'>liskl/homelab</a></strong> repo - bootstrapped k8s with cert-manager + private CA HTTPS, deployed FlashPaper encrypted pastebin, home.liskl.com landing page, and the Furious Fruits HTML5 game</li>
             </ul>
           </li>
           <li>
@@ -307,7 +307,7 @@
                   <li class='sub'><strong>Terraform</strong> - Infrastructure as Code for client infrastructure deployments</li>
                   <li class='sub'><strong>Infracost</strong> - Cloud cost estimation and optimization tooling</li>
                   <li class='sub'><strong>AWS Services</strong> - CloudFront, ALB configuration, EKS infrastructure</li>
-                  <li class='sub'><strong>K3s</strong> - Lightweight Kubernetes contributions and documentation</li>
+                  <li class='sub'><strong>K8s</strong> - Lightweight Kubernetes contributions and documentation</li>
                 </ul>
               </li>
               <li class='sub'>Key Focus Areas:

--- a/src/index.tmpl
+++ b/src/index.tmpl
@@ -307,7 +307,7 @@
                   <li class='sub'><strong>Terraform</strong> - Infrastructure as Code for client infrastructure deployments</li>
                   <li class='sub'><strong>Infracost</strong> - Cloud cost estimation and optimization tooling</li>
                   <li class='sub'><strong>AWS Services</strong> - CloudFront, ALB configuration, EKS infrastructure</li>
-                  <li class='sub'><strong>K8s</strong> - Lightweight Kubernetes contributions and documentation</li>
+                  <li class='sub'><strong>K3s</strong> - Lightweight Kubernetes contributions and documentation</li>
                 </ul>
               </li>
               <li class='sub'>Key Focus Areas:


### PR DESCRIPTION
## Summary

Surfacing recent public work on the homepage's "Recent News" section. Sourced from public github.com/liskl activity per the CLAUDE.md "Adding Recent Activities" workflow; anonymization rules respected (public repo names, technologies, architectural patterns only).

### New entries

- **2026** (consolidated) - Open Source / Personal Projects sub-section + Technologies & Tools sub-section:
  - [`code-review-graph`](https://github.com/liskl/code-review-graph), [`cc-skill-visual-explainer`](https://github.com/liskl/cc-skill-visual-explainer), [`coolledux-controller`](https://github.com/liskl/coolledux-controller), [`FlashPaper`](https://github.com/liskl/FlashPaper), [`ai-consensus-poc`](https://github.com/liskl/ai-consensus-poc), [`kind-aws-irsa-example`](https://github.com/liskl/kind-aws-irsa-example)
  - Tech: k3s + Flux GitOps, kgateway / Gateway API, cert-manager, OpenTelemetry + Grafana + Loki / Tempo, Go (BLE / scraping / OTel), Claude Code agent skills
- **May 2026** - liskl.com migrated from AWS S3 + CloudFront onto the homelab k3s cluster; plex-db-analyzer OpenTelemetry + Grafana work
- **Mar 2026** - Published `code-review-graph` (codebase knowledge graph for Claude Code) and `cc-skill-visual-explainer` (visual explainer skill)
- **Dec 2025** - Shipped [`backstage-adr-plugin`](https://github.com/liskl/backstage-adr-plugin) v1 across three phases; kicked off the [`liskl/homelab`](https://github.com/liskl/homelab) repo (cert-manager + private CA HTTPS, FlashPaper, home.liskl.com, Furious Fruits)
- **2025** consolidated - added Open Source / Personal Projects sub-section to the existing entry (`backstage-adr-plugin`, `llm-council`, `esphome-levoit-air-purifier`, `k8s-rds`)

All new in-repo links use root-relative paths; external GitHub URLs stay absolute as expected.

## Test plan

- [x] `src/generate_site.sh` runs clean; `site/index.html` regenerated.
- [x] Grep verifies 0 `https://www.liskl.com/...` in `src/` or `site/index.html` (relative-URL convention upheld).
- [x] 4 new section headers render in `site/index.html` (`2026`, `May 2026`, `Mar 2026`, `Dec 2025`).
- [ ] CI ships `v0.2.0` (feat: → minor bump); Flux image-automation rolls the homelab pod.
- [ ] Spot-check the live page after rollout for the new entries and intact older years.